### PR TITLE
Service upgrade

### DIFF
--- a/src/aura/EventService/EventService.cmp
+++ b/src/aura/EventService/EventService.cmp
@@ -5,12 +5,12 @@
 
   <aura:method name="fireAppEvent" action="{! c.handleFireApplicationEvent }">
     <aura:attribute name="eventKey" type="String"/>
-    <aura:attribute name="eventValue" type="String"/>
+    <aura:attribute name="eventValue" type="Object"/>
   </aura:method>
 
   <aura:method name="fireCompEvent" action="{! c.handleFireComponentEvent }">
     <aura:attribute name="eventKey" type="String"/>
-    <aura:attribute name="eventValue" type="String"/>
+    <aura:attribute name="eventValue" type="Object"/>
   </aura:method>
 
 </aura:component>

--- a/src/aura/MessageService/MessageService.cmp
+++ b/src/aura/MessageService/MessageService.cmp
@@ -1,4 +1,4 @@
-<aura:component >
+<aura:component>
 
   <c:EventService aura:id="eventService_messaging"/>
   <lightning:overlayLibrary aura:id="overlayLib"/>
@@ -15,14 +15,15 @@
     <aura:attribute name="auraId" type="string" default="modal"/>
     <aura:attribute name="headerLabel" type="String"/>
     <aura:attribute name="body" type="String"/>
+    <aura:attribute name="bodyParams" type="Object"/>
     <aura:attribute name="mainActionReference" type="String"/>
     <aura:attribute name="mainActionLabel" type="String" default="Save"/>
-    <aura:attribute name="closeKey" type="String"/>
-    <aura:attribute name="closeValue" type="String"/>
+    <!-- <aura:attribute name="closeKey" type="String"/> -->
+    <!-- <aura:attribute name="closeValue" type="Object"/> -->
   </aura:method>
 
-  <aura:method name="notification" action="{! c.handleUtilToast }">
+  <!-- <aura:method name="notification" action="{! c.handleUtilNotification }">
     <aura:attribute name="title" type="String"/>
-  </aura:method>
+  </aura:method> -->
 
 </aura:component>

--- a/src/aura/MessageService/MessageServiceController.js
+++ b/src/aura/MessageService/MessageServiceController.js
@@ -1,6 +1,5 @@
 ({
   handleShowToast : function(component, event, helper) {
-    console.log("toasting")
     var params = event.getParam("arguments");
     helper.showToast(
       params.title,
@@ -19,6 +18,12 @@
       $A.getCallback(function(error, modalBody) {
         if (modalBody.isValid()) {
 
+          // if mainActionReference has a c. prefix, it means we want an action on the body just created
+          var str = String(params.mainActionReference);
+          if (str.startsWith("c.")) {
+            params.mainActionReference = modalBody.getReference(params.mainActionReference);
+          }
+
           helper.createButton(params,
             $A.getCallback(function(error, mainAction) {
               if (mainAction.isValid()) {
@@ -36,12 +41,15 @@
                         header: params.headerLabel,
                         body: modalBody, 
                         footer: completedFooter,
-                        showCloseButton: true,
-                        closeCallback: function() {
-                          if (params.closeKey) {
-                            eventService.fireCompEvent(params.closeKey, params.closeValue);
-                          }
-                        }
+                        showCloseButton: true
+                        // Haven't had a use for this yet so temporarily deprecating
+                        // closeCallback: function() {
+                        //   if (params.closeKey) {
+                        //     eventService.fireCompEvent(params.closeKey, params.closeValue);
+                        //   }
+                        // }
+                      }).then(function (overlay) {
+                        eventService.fireAppEvent("MODAL_READY");
                       });
                     }
                   }

--- a/src/aura/MessageService/MessageServiceHelper.js
+++ b/src/aura/MessageService/MessageServiceHelper.js
@@ -16,14 +16,20 @@
   },
   createBody : function(params, ctrlCallback) {
     var componentType = params.body.split(":")[0];
+    var componentParams = {};
+
+    // if we had some bodyParams, let's set the target modal body with their data
+    if (!$A.util.isEmpty(params.bodyParams)) {
+      Object.keys(params.bodyParams).forEach(function(v,i,a) {
+        componentParams[v] = params.bodyParams[v];
+      });
+    }
 
     switch(componentType) {
       case "c" : //custom component
         $A.createComponent(
           params.body,
-          {
-            "aura:id": params.auraId,
-          },
+          componentParams,
           function(newModalBody, status, errorMessage){
             if (status === "SUCCESS") {
               ctrlCallback(null, newModalBody);

--- a/src/aura/ServiceAppEvent/ServiceAppEvent.evt
+++ b/src/aura/ServiceAppEvent/ServiceAppEvent.evt
@@ -1,5 +1,5 @@
 <!--c:ServiceAppEvent-->
 <aura:event type="APPLICATION">
   <aura:attribute name="appEventKey" type="String"/>
-  <aura:attribute name="appEventValue" type="String"/>
+  <aura:attribute name="appEventValue" type="Object"/>
 </aura:event>

--- a/src/aura/ServiceCompEvent/ServiceCompEvent.evt
+++ b/src/aura/ServiceCompEvent/ServiceCompEvent.evt
@@ -1,5 +1,5 @@
 <!--c:ServiceCompEvent-->
 <aura:event type="COMPONENT">
   <aura:attribute name="compEventKey" type="String"/>
-  <aura:attribute name="compEventValue" type="String"/>
+  <aura:attribute name="compEventValue" type="Object"/>
 </aura:event>

--- a/src/aura/ServiceHeader/ServiceHeader.cmp
+++ b/src/aura/ServiceHeader/ServiceHeader.cmp
@@ -16,7 +16,7 @@
 
     <lightning:layout horizontalAlign="center" multipleRows="true">
       <lightning:layoutItem class="slds-m-bottom_medium" size="10">
-        <c:ServiceProgressIndicator aura:id="headerIndicator"/>
+        <!-- <c:ServiceProgressIndicator aura:id="headerIndicator"/> -->
       </lightning:layoutItem>
       <lightning:layoutItem padding="horizontal-medium" size="5">
         <lightning:combobox aura:id="selectItem"

--- a/src/aura/ServiceLargeSection/ServiceLargeSectionController.js
+++ b/src/aura/ServiceLargeSection/ServiceLargeSectionController.js
@@ -2,46 +2,43 @@
   handleOpenComponentModal : function(component) {
     var msgService = component.find("messageService_large");
     var selectedArr = component.find("searchTable").getSelectedRows();
-    var modalMainActionReference = component.getReference("c.handleModalSaveEvent");
 
     msgService.modal(
       "update-address-modal",
       "Update Address: "+selectedArr.length+" Row(s)",
       "c:ServiceSmallSection",
-      modalMainActionReference,
+      {
+        "contactList": selectedArr
+      },
+      "c.handleUpdateMultiAddress",
       "Update"
     );
   },
-  // If we need to send data from this component to the modal, we seem to have to do it via application event 
-  // since there is a different hierarchy. component.find() from either this component or the modal cannot find one another
-  handleModalSaveEvent : function(component, event) {
-    var eventService = component.find("eventService_large");
-    var selectedArr = component.find("searchTable").getSelectedRows();
-
-    eventService.fireAppEvent("CONTACT_ROWS", JSON.stringify(selectedArr));
-  },
   handleApplicationEvent : function(component, event, helper) {
     var params = event.getParams();
-    var service = component.find("service_large");
 
-    if (params.appEventKey == "ACCOUNT_ID_SELECTED" || params.appEventKey == "CONTACTS_UPDATED") {
-      var tableColumns = helper.getTableColumnDefinition();
+    switch(params.appEventKey) {
+      case "ACCOUNT_ID_SELECTED":
+      case "CONTACTS_UPDATED":
+        var service = component.find("service_large");
+        var tableColumns = helper.getTableColumnDefinition();
 
-      service.fetchContactsByAccountId(
-        params.appEventValue,
-        $A.getCallback(function(error, data) {
-          if (data) {
-            component.set("v.tableData", data);
-            component.set("v.tableColumns", tableColumns);
-          } else {
-            // Fail silently
-            console.log(error);
-          }
-        })
-      );
-    }
-    if (params.appEventKey == "HEADER_CLEARTABLE") {
-      component.set("v.tableData", null);
+        service.fetchContactsByAccountId(
+          params.appEventValue,
+          $A.getCallback(function(error, data) {
+            if (data) {
+              component.set("v.tableData", data);
+              component.set("v.tableColumns", tableColumns);
+            } else {
+              // Fail silently
+              console.log(error);
+            }
+          })
+        );
+        break;
+      case "HEADER_CLEARTABLE":
+        component.set("v.tableData", null);
+        break;
     }
   },
 })

--- a/src/aura/ServiceSmallSection/ServiceSmallSection.cmp
+++ b/src/aura/ServiceSmallSection/ServiceSmallSection.cmp
@@ -11,8 +11,6 @@
   <aura:attribute name="contactMailingState" type="String"/>
   <aura:attribute name="contactMailingZip" type="Integer"/>
 
-  <aura:handler event="c:ServiceAppEvent" action="{! c.handleApplicationEvent }"/>
-
   <lightning:card >
     <aura:set attribute="title">
     </aura:set>

--- a/src/aura/ServiceSmallSection/ServiceSmallSectionController.js
+++ b/src/aura/ServiceSmallSection/ServiceSmallSectionController.js
@@ -1,12 +1,5 @@
 ({
-  handleApplicationEvent : function(component, event, helper) {
-    var params = event.getParams();
-
-    if (params.appEventKey == "CONTACT_ROWS") {
-      var parsedValue = JSON.parse(params.appEventValue);
-      
-      component.set("v.contactList", parsedValue);
-      helper.updateMultiAddress(component);
-    }
+  handleUpdateMultiAddress : function(component, event, helper) {
+    helper.updateMultiAddress(component);
   },
 })


### PR DESCRIPTION
- Events support objects now (they did before due to lightning's fast and loose interpretation of "string" when being thrown around between components, but it's strongly typed now).

- MessageService can now take parameters from the calling component - no need to fire application events to "set" parameters anymore

- MessageService can now specify where the target (JS) controller action reference is, specifically, it can be told that you want a main action from the target modal body being constructed. This keeps both the modal body component and it's save logic in one place (the modal body component). Much cleaner, IMO